### PR TITLE
feat: add support for jest test paths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "data-snapshot",
-  "version": "1.0.0-beta1",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/__tests__/utils.spec.js
+++ b/src/__tests__/utils.spec.js
@@ -34,6 +34,16 @@ const macErrorStack = `Error
     at promise.then (/Users/me/data-snapshot/node_modules/jest-jasmine2/build/queue_runner.js:73:82)
     at <anonymous>`;
 
+const originalGetState = global.expect.getState;
+
+beforeEach(() => {
+  delete global.expect.getState;
+});
+
+afterEach(() => {
+  global.expect.getState = originalGetState;
+});
+
 test('handles windows error', () => {
   expect(callingFilePath(windowsErrorStack)).toBe(
     'C:\\Users\\me\\data-snapshot\\src\\__tests__\\index.spec.js'
@@ -43,5 +53,14 @@ test('handles windows error', () => {
 test('handles mac error', () => {
   expect(callingFilePath(macErrorStack)).toBe(
     '/Users/me/data-snapshot/src/__tests__/index.spec.js'
+  );
+});
+
+test('handles `testPath` in jest environment', () => {
+  global.expect.getState = () => ({
+    testPath: '/Users/me/data-snapshot/src/__tests__/mocked.spec.js'
+  });
+  expect(callingFilePath()).toBe(
+    '/Users/me/data-snapshot/src/__tests__/mocked.spec.js'
   );
 });

--- a/src/utils.js
+++ b/src/utils.js
@@ -6,6 +6,10 @@
 
 // Generate a stacktrace and get the filepath of where dataSnapshot was called
 export const callingFilePath = (stack: string) => {
+  // Return test path when running with Jest
+  if (global.expect && typeof global.expect.getState === 'function') {
+    return global.expect.getState().testPath;
+  }
   const callingFileStack = stack.split('\n')[2].split(/\s/);
   const callingFile =
     callingFileStack[callingFileStack.length - 1]


### PR DESCRIPTION
Hey there 👋

I sounds a bit specific feature for Jest, but what do you think about relying on Jests's `testPath`? It allows to move `dataSnapshot` call into separate file or even individual module, but still resolving snapshots directory correctly.

Currently it's not possible to move `dataSnapshot` call outside of spec file as it resolves whatever path you'll move it into.