### PR TITLE
Add renovate config for repository.

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -1,0 +1,54 @@
+name: 🐞 Bug
+description: Report a bug/issue
+title: "[BUG] <title>"
+labels: [Bug, Needs Triage]
+body:
+- type: textarea
+  attributes:
+    label: Current Behavior
+    description: A concise description of what you're experiencing.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Expected Behavior
+    description: A concise description of what you expected to happen.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Steps To Reproduce
+    description: Steps to reproduce the behavior. Ideally provide a minimal reproduction repo.
+    placeholder: |
+      1. In this environment...
+      2. With this config...
+      3. Run '...'
+      4. See error...
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Environment
+    description: |
+      examples:
+        - **OS**: Ubuntu 20.04
+        - **Node Version**: 13.14.0
+        - **Package Manager**: yarn
+        - **Package Manager Version**: 2.3.1
+    value: |
+        - OS:
+        - Node Version:
+        - Package Manager:
+        - Package Manager Version:
+    render: markdown
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Anything else?
+    description: |
+      Links? References? Anything that will give us more context about the issue you are encountering!
+
+      Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+  validations:
+    required: false

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.yml
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.yml
@@ -1,0 +1,28 @@
+name: Feature Request
+description: Suggest a feature for this project
+title: "[Feat] <title>"
+body:
+- type: textarea
+  attributes:
+    label: Problem Statement
+    description: A clear and concise description of what you want and what your use case is.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Proposed Solution
+    description: A clear and concise description of what you want to happen.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Alternatives Considered
+    description: A clear and concise description of any alternative solutions or features you've considered.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Additional Context
+    description: Please provide any other information that may be relevant.
+  validations:
+    required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+<!-- Please check the contributing guide before entering PRs: https://github.com/wayfair/one-version/blob/main/CONTRIBUTING.md -->
+
+## Description
+
+<!-- Please provide a meaningful description of what this change will do, or is for. Bonus points for including links to related issues, other PRs, or technical references. -->
+
+## Type of Change
+
+- [ ] Bug Fix
+- [ ] New Feature
+- [ ] Breaking Change
+- [ ] Refactor
+- [ ] Documentation
+- [ ] Other (please describe)

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,73 @@
+name: PR Checks
+
+on: # Rebuild any PRs and main branch changes
+  push:
+    branches:
+      - main
+  pull_request:
+
+
+jobs:
+
+  install-node-modules:
+    name: Install Dependencies
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14.x
+          cache: yarn
+      - name: Validate cache
+        run: yarn install --frozen-lockfile
+
+  test:
+    name: Run Jest Tests
+    runs-on: ubuntu-latest
+    needs: install-node-modules
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14.x
+          cache: yarn
+      - name: install
+        run: yarn install --frozen-lockfile
+      - name: test
+        run: yarn test
+
+  lint:
+    name: Run Lints
+    runs-on: ubuntu-latest
+    needs: install-node-modules
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14.x
+          cache: yarn
+      - name: install
+        run: yarn install --frozen-lockfile
+      - name: lint
+        run: yarn lint
+      - name: markdown lint
+        run: yarn lint:md
+
+  prettier:
+    name: Check Formatting
+    runs-on: ubuntu-latest
+    needs: install-node-modules
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14.x
+          cache: yarn
+      - name: install
+        run: yarn install --frozen-lockfile
+      - name: format-check
+        run: yarn format:check

--- a/.github/workflows/renovate_linting.yml
+++ b/.github/workflows/renovate_linting.yml
@@ -1,0 +1,12 @@
+name: Renovate Config Linting
+on: [pull_request]
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: 🧼 lint renovate config # Validates changes to renovate.json config file
+        uses: suzuki-shunsuke/github-action-renovate-config-validator@v0.1.2
+        with:
+          config_file_path: 'renovate.json'

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base",
+    ":dependencyDashboard",
+    ":rebaseStalePrs"
+  ],
+  "schedule": [
+    "before 3am every weekday" 
+  ],
+  "enabledManagers": [
+    "npm",
+    "dockerfile",
+    "github-actions"
+  ],
+  "packageRules": [
+    {
+      "matchPackagePrefixes": ["babel"],
+      "groupName": "Babel"
+    },
+    {
+      "matchPackagePrefixes": ["eslint"],
+      "groupName": "Eslint"
+    },
+    {
+      "matchPackagePrefixes": ["flow"],
+      "groupName": "Flow"
+    },
+    {
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "groupName": "Minor Packages",
+      "automerge": true
+    }
+  ]
+}


### PR DESCRIPTION
Resolves #4 
Iv'e also added a few other wayfair standard thing such as pull request template, issue template, and PR check github action. If you don't want that included then just let me know. I noticed them being used on https://github.com/wayfair/one-version and assumed it'd be something wayfair would like to be standard across the board.

 - [x] I have read the Adding Renovate to Existing Projects guide.
 - [x] I have assigned this issue to myself avoid duplicating efforts with other potential contributors.
 - [x] I have verified this repository does not already have Renovate configured (or proposed in an open PR by another contributor).
- [x]  If the renovate[bot] account has already auto-filed a Configure Renovate PR in this repository, I confirm that I will create a separate PR under my own GitHub account, using the initial PR as inspiration.
 - [x] I confirm that I have added Renovate linting to this project's existing CI pipeline, or have created a new linting workflow if one doesn't already exist.
 - [x] If this repository is currently configured to use GitHub's Dependabot, my PR will also deprecate support for Dependabot in order to avoid conflicts with Renovate.